### PR TITLE
HOTT-5143: Extract the DB FILENAME from the DB URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,10 @@ commands:
           name: "Prepare database"
           command: |
             wget --user $BASIC_USER --password $BASIC_PASSWORD $DUMP_URL
-            gunzip tariff-merged-staging.sql.gz
             createdb -h localhost -U postgres electronic_tariff_file
-            psql -h localhost -U postgres electronic_tariff_file < tariff-merged-staging.sql
+
+            GZ_DB_FILENAME=$(basename $DUMP_URL) # extract filename from DB URL
+            gunzip -c $GZ_DB_FILENAME | psql -h localhost -U postgres electronic_tariff_file
 
 jobs:
   test:


### PR DESCRIPTION
### What?

Extract the DB FILENAME from the DB URL, which is the base of the var DUMP_URL.

This way, the DB can be easily switched just by changing the URL (without specifying the filename).


### Why?
To change $DUMP_URL without changing the filename in config.yml
