### PR TITLE
BAU: Update cron to deliver emails at 8:30 AM UK time

### DIFF
--- a/.github/workflows/thursday.yml
+++ b/.github/workflows/thursday.yml
@@ -2,7 +2,7 @@ name: Thursday workflow
 
 on:
   schedule:
-    - cron: '30 08 * * 4' # Every Thursday at 08:30
+    - cron: '00 07 * * 4' # Every Thursday around 08:30
   workflow_dispatch:
     inputs:
       ref:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Dependencies are managed using pip-tools.
 - Add new packages to requirements.in (runtime dependencies) or requirements_dev.in (dev-only).
 
 - Then recompile the locked .txt files:
+
 `pip-compile --generate-hashes --output-file=requirements.txt requirements.in`
+
 `pip-compile --generate-hashes --output-file=requirements_dev.txt requirements_dev.in`
 
 This ensures all versions are pinned and avoids conflicts.
@@ -46,9 +48,11 @@ This ensures all versions are pinned and avoids conflicts.
 #### Examples
 
 To create a data file for the UK for a specific date (21st July 23)
+
 `python create.py uk 2023-07-21`
 
 To create a data file for XI for today
+
 `python create.py xi`
 
 ### To parse an existing electronic Tariff file:


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Updated the GitHub Actions schedule (cron expression) to ensure emails are delivered at the correct time.

### Why?

I am doing this because:

- The previous cron setting was '30 08 * * 4', which triggered the job at 8:30 AM UTC.
- Since we are in the UK (currently on BST), the emails were actually being sent around 9:30–10:00 AM local time.
- I’ve updated the cron to '00 07 * * 4' so the job runs at 8:00 AM UTC, aligning the delivery to approximately 8:30 AM UK local time.


### AC
