### PR TITLE
Remove pip caching from setup-python

### DIFF
--- a/.github/workflows/thursday.yml
+++ b/.github/workflows/thursday.yml
@@ -40,7 +40,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-        cache: 'pip'
 
     - name: Cache Python dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [ ] Removed the cache: pip option from the setup-python step

### Why?

I am doing this because:

- The workflow dynamically generates requirements.txt using pip-compile, so caching at setup-python time fails due to the absence of the file.


### AC
