### PR TITLE
BAU: Fix slack-notify action inputs for updated interface

### DIFF
--- a/.github/workflows/thursday.yml
+++ b/.github/workflows/thursday.yml
@@ -86,5 +86,6 @@ jobs:
         - uses: actions/checkout@v4
         - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
           with:
-            result: ${{ needs.generate-electronic-tariff-file.result }}
-            slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+            webhook: ${{ secrets.SLACK_WEBHOOK }}
+            color: ${{ needs.generate-electronic-tariff-file.result }}
+            message: "Electronic Tariff File generation ${{ needs.generate-electronic-tariff-file.result }}"


### PR DESCRIPTION
### What?

- [x] Update `slack-notify` action inputs in `thursday.yml` to match the new interface in `trade-tariff-tools`

### Why?

The `slack-notify` action in `trade-tariff-tools` was updated with a new interface:
- `slack_webhook` was renamed to `webhook`
- `result` was removed; `color` now accepts `success`/`failure`/`cancelled` directly
- `message` is now a required input

This caused the Thursday workflow's notification step to fail with `curl: (3) URL rejected: Malformed input to a URL function` because the webhook URL was not being passed through correctly.