### PR TITLE
HMRC-2267: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Jira link
[HMRC-2267](https://transformuk.atlassian.net/browse/HMRC-2267)

### What?

- Added Dependabot config for github-actions and pip

### Why?

To enable automated dependency updates across GitHub Actions and pip.
