### PR TITLE
Update workflow to add contents: write permission

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -23,7 +23,7 @@ on:
           - 'false'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Updated `close-stale-pull-requests.yml` workflow to add `contents: write` permission
### Why?

I am doing this because:

- It should fix the error `The workflow is requesting 'contents: write', but is only allowed 'contents: read'.`

### AC
